### PR TITLE
Add ebs optimized to ignore_changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,8 @@ resource "aws_instance" "this" {
   lifecycle {
     ignore_changes = [
       key_name,
-      user_data
+      user_data,
+      ebs_optimized
     ]
   }
 }


### PR DESCRIPTION
Since we don't really need to change this ever, all instances that we use are ebs optimized by default.